### PR TITLE
Fix shell syntax error by removing trailing semicolon from -v flag

### DIFF
--- a/vars/container.groovy
+++ b/vars/container.groovy
@@ -444,7 +444,7 @@ def _goTestCommand(Map test) {
 
     args.add("-timeout=${test.timeout}")
 
-    args.add('-v;')
+    args.add('-v')
 
     return [args, test]
 }


### PR DESCRIPTION
This pull request makes a minor adjustment to the `_goTestCommand` function in `vars/container.groovy`. The change removes an unnecessary semicolon from the `-v` argument, ensuring proper command formatting.The hardcoded semicolon in args.add('-v;') caused a shell syntax error when the calling pipeline appended '| tee go-test.log'. The shell parsed the semicolon as a command terminator, leaving the pipe with no left-hand command: '... -v; | tee go-test.log'.

Remove the semicolon so the argument is simply '-v'. Command chaining is the responsibility of the layer that assembles the full shell command.