### PR TITLE
Add checkoutMultipleIsolated for declarative checkout without cleanup

### DIFF
--- a/src/test/groovy/ProjectScriptTest.groovy
+++ b/src/test/groovy/ProjectScriptTest.groovy
@@ -1,0 +1,77 @@
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+import static org.assertj.core.api.Assertions.assertThat
+
+/**
+* Tests for vars/project.groovy — orchestration logic tests.
+*
+* Project functions are orchestration wrappers that compose lower-level
+* modules (tofu, ansible, infrastructure, project, config). Tests here
+* focus on testable behaviors:
+* - checkoutMultipleIsolated: workspace isolation and cleanup
+*/
+class ProjectScriptTest extends BasePipelineTest {
+
+    def script
+    def checkedOut = []
+    def deletedDirectories = []
+    def currentDirectory = '.'
+
+    @Override
+    @BeforeEach
+    void setUp() {
+        super.setUp()
+        helper.registerAllowedMethod('echo', [String.class]) { }
+        helper.registerAllowedMethod('error', [String.class]) { String message ->
+            throw new RuntimeException(message)
+        }
+        helper.registerAllowedMethod('dir', [String.class, Closure.class]) { String path, Closure body ->
+            def previous = currentDirectory
+            currentDirectory = path
+            try {
+                body.call()
+            } finally {
+                currentDirectory = previous
+            }
+        }
+        helper.registerAllowedMethod('deleteDir', []) {
+            deletedDirectories << currentDirectory
+        }
+        helper.registerAllowedMethod('checkout', [Map.class]) { Map scmConfig ->
+            checkedOut << [directory: currentDirectory, config: scmConfig]
+        }
+        script = loadScript('project.groovy')
+    }
+
+    @Test
+    @DisplayName('isolated checkout scopes cleanup and does not inherit SCM extensions')
+    void checkoutMultipleIsolated_keepsRepositoriesSeparate() {
+        def paths = script.checkoutMultipleIsolated([
+            [repository: 'https://github.com/rancher/tests', branch: 'main', target: 'tests'],
+            [repository: 'https://github.com/rancher/qa-infra-automation', branch: 'main', target: 'qa-infra-automation']
+        ])
+
+        assertThat(paths).containsExactly('./tests', './qa-infra-automation')
+        assertThat(deletedDirectories).containsExactly('tests', 'qa-infra-automation')
+        assertThat(checkedOut*.directory).containsExactly('tests', 'qa-infra-automation')
+        assertThat(checkedOut[0].config.extensions).containsExactly([$class: 'CleanCheckout'])
+        assertThat(checkedOut[1].config.extensions).containsExactly([$class: 'CleanCheckout'])
+    }
+
+    @Test
+    @DisplayName('isolated checkout rejects workspace root and traversal targets')
+    void checkoutMultipleIsolated_rejectsUnsafeTargets() {
+        for (target in ['.', '../tests', '/tmp/tests']) {
+            RuntimeException failure = null
+            try {
+                script.checkoutMultipleIsolated([[repository: 'https://example.test/repo', target: target]])
+            } catch (RuntimeException e) {
+                failure = e
+            }
+            assertThat(failure).isNotNull()
+            assertThat(failure.message).contains('workspace-relative subdirectory')
+        }
+    }
+}

--- a/vars/project.groovy
+++ b/vars/project.groovy
@@ -137,3 +137,56 @@ def checkoutMultiple(List<Map> repositories) {
 
     return targetPaths
 }
+
+/**
+ * Check out multiple repositories without inheriting extensions from the
+ * Pipeline's SCM. Cleanup is scoped to each target directory, so one checkout
+ * cannot remove another repository from the workspace.
+ *
+ * Parameters:
+ *   repositories (List<Map>, required) - List of repository configuration maps, each with:
+ *   repository (String,  required) - Full HTTPS or SSH URL of the Git repository.
+ *   branch     (String,  optional) - Branch name to check out. Defaults to 'main'.
+ *   target     (String,  required) - Relative subdirectory within the workspace
+ *
+ * Returns a List of target directory paths (e.g. ['./tests', './infra']).
+ *
+ * Example:
+ *   def dirs = project.checkoutMultipleIsolated([
+ *       [repository: 'https://github.com/example/repo.git', branch: 'main', target: 'repo']
+ *   ])
+ * // dirs → ['./repo']
+ */
+def checkoutMultipleIsolated(List<Map> repositories) {
+    if (!repositories) {
+        error 'At least one repository must be provided for checkoutMultipleIsolated.'
+    }
+
+    def targetPaths = []
+    repositories.each { repoConfig ->
+        def repository = repoConfig.repository
+        def branch = repoConfig.branch ?: 'main'
+        def target = repoConfig.target
+
+        if (!(repository && target)) {
+            error "Each repository entry must include 'repository' (URL) and 'target' (directory). Got: ${repoConfig}"
+        }
+        if (target == '.' || target.startsWith('/') || target.tokenize('/').contains('..')) {
+            error "Repository target must be a workspace-relative subdirectory. Got: ${target}"
+        }
+
+        steps.echo "Cloning ${repository} (${branch}) into ${target}"
+        steps.dir(target) {
+            steps.deleteDir()
+            steps.checkout([
+                $class: 'GitSCM',
+                branches: [[name: "*/${branch}"]],
+                extensions: [[$class: 'CleanCheckout']],
+                userRemoteConfigs: [[url: repository]]
+            ])
+        }
+        targetPaths << "./${target}"
+    }
+
+    return targetPaths
+}


### PR DESCRIPTION
Adds a new checkout function that uses the preferred declarative approach to repo checkouts.
- Intentionally scopes cleanup to the checkout dir ONLY, does not cleanup all checked out directories if only 1 is cleaned up.
- Avoids inheriting `scm.extensions`